### PR TITLE
Fix redirect matching for Blogger URLs with query params

### DIFF
--- a/redirect.php
+++ b/redirect.php
@@ -13,6 +13,7 @@ function btw_importer_handle_old_permalink_redirect() {
     $original_request_uri = '';
     if (isset($_SERVER['REQUEST_URI'])) {
         $original_request_uri = sanitize_text_field(wp_unslash($_SERVER['REQUEST_URI']));
+        $original_request_uri = parse_url($original_request_uri, PHP_URL_PATH) ?? $original_request_uri;
     }
 
     // Remove trailing slash if original request ends with .html


### PR DESCRIPTION
Strip query params from before checking permalinks so redirects work for URLs with query params after like `?m=1`.

Currently, URLs such as `/post.html?m=1` fail to match and don't redirect.
